### PR TITLE
Update customize.sh

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -4,8 +4,10 @@ FILE=/system/etc/fonts.xml
 FILENAME=$(sed -ne '/<family lang="und-Zsye".*>/,/<\/family>/ {s/.*<font weight="400" style="normal">\(.*\)<\/font>.*/\1/p;}' $MIRRORPATH$FILE)
 for i in $FILENAME
 do
-    ui_print "- Copying fonts files to $i"
-    cp -f $MODPATH/system/fonts/Blobmoji.ttf $MODPATH/system/fonts/$i
+    ui_print "- Soft linking fonts files to $i"
+    ln -sf $MODPATH/system/fonts/Blobmoji.ttf $MODPATH/system/fonts/$i
 done
+ui_print "- Remove soft link names *flags*"
+rm -f *flags*
 
 rm $MODPATH/LICENSE* 2>/dev/null


### PR DESCRIPTION
Use soft link insted of making many copys of the font file to save storage space; Do not modify "NotoColorEmojiFlags.ttf" to ensure that some emojis such as "🏴‍☠️" are displayed normally instead of being separated.